### PR TITLE
Simplify testing with npm test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,9 @@ The node server takes in a request via the browser and establishes a socket.io l
 
 ### Testing
 
-* install mocha globally
+* > npm test
 
-* npm install -g mocha
-
-* run the tests
-
-* > mocha 
+* alternatively, install mocha globally (npm install -g mocha) and run mocha from project root
 
 ### Wiki
 

--- a/package.json
+++ b/package.json
@@ -25,9 +25,14 @@
     "collections": "latest",
     "node-html-encoder": "latest",
     "node-uuid": "latest",
-    "underscore": "latest",
-    "mocha": "latest"
+    "underscore": "latest"
   },
+  "devDependencies": {
+    "mocha": "*"
+  },
+  "scripts": {
+     "test": "node_modules/.bin/mocha"
+   },
   "preferGlobal": true,
   "private": true,
   "license": "BSD-3-Clause"


### PR DESCRIPTION
This commit specifies mocha dependencies to allow a simple 'npm test' command. Also, in eliminates the need for needing to globally install mocha.
