### PR TITLE
Updated referer to referrers for JSON to service serialization

### DIFF
--- a/lib/util/serializer.js
+++ b/lib/util/serializer.js
@@ -31,7 +31,7 @@ module.exports = {
                    
     // Add the top level request information
     if(typeof requestorParams['api_ver'] != 'undefined'){ message += ',"api_ver":"' + requestorParams['api_ver'] + '"'; }
-    if(typeof requestorParams['referrer'] != 'undefined'){ message += ',"referrer":"' + requestorParams['referrer'] + '"'; }
+    if(typeof requestorParams['referrers'] != 'undefined'){ message += ',"referrers":"' + requestorParams['referrers'] + '"'; }
     if(typeof requestorParams['requestor_ip'] != 'undefined'){ message += ',"requestor_ip":"' + requestorParams['requestor_ip'] + '"'; }
     if(typeof requestorParams['requestor_affiliation'] != 'undefined'){ message += ',"requestor_affiliation":"' + requestorParams['requestor_affiliation'] + '"'; }
     if(typeof requestorParams['unmapped'] != 'undefined'){ message += ',"unmapped":"' + requestorParams['unmapped'] + '"'; }


### PR DESCRIPTION
minor tweak to make serializer to better label the referrers array in the JSON sent to services. It was labeled 'referrer'.
